### PR TITLE
Add commands for app bootstrap and dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Feel free to create a pull request to help improve this project.
 
 ## How to run
 
-1. Navigate to the **server** directory of the project and run **npm install** in your command prompt
-2. After node packages is downloaded, then run command **npm run local**
-3. Navigate to the **client** directory of the project and open the **index.html** file in your web browser
+1. Run **npm run bootstrap** - this commands installs node_modules in the root, client and the server directory.
+2. Run **npm run dev** - this commands ups the serverless setup in server directory and concurrently, ups the webpack-express-server in the client directory.
+3. Open [http://localhost:8080](http://localhost:8080) in a web browser to start using the app.
 
 ## Other features
 
@@ -23,10 +23,10 @@ Feel free to create a pull request to help improve this project.
 - If you are someone who prefers the CLI, run:
 
 ```
-$: npm run local -- --port 5000 # optionally on a diffrent port
+$: npm run local -- --port 5000 # optionally on a different port
 ```
 
-By default, this starts the server on port 3000. If you prefer
+By default, this starts the (backend) server on port 3000. If you prefer
 to change it you can, by passing `--port 3001` and also remember to update
 the port address in `index.js` which is in the frontend `client` folder.
 
@@ -53,20 +53,16 @@ You can see the page in **http://localhost:8080/**
 
 For integration testing, [Cypress](https://www.cypress.io/) has been used. Following test cases have been taken care of:
 
-* When an error occurs,
-[x] Loader is not visible.
-[x] A proper error message is displayed.
+* When an error occurs,  
+[x] Loader is not visible.  
+[x] A proper error message is displayed.  
 
 * For suggestions of more test cases/scenarios, please update [Issue number 31](https://github.com/tminussi/hacktoberfest-2018-checker/issues/31) 
 
 Instructions to start the Cypress server:
 
-* Please ensure that your backend server is running using the command **npm run local** in **server** directory(refer to 'How to run' section).
-* Also, ensure that the dev server is running in the **client** directory (refer to 'Frontend' section) - i.e., you are able to access **index.html** at your [localhost:8080](http://localhost:8080)
-
-Now, in the root directory, which contains the client and server directories, run the following commands:
-
-* **npm i** - (first time only, this installs cypress)
+* **npm run bootstrap** - (If you have already ran this command before, you don't need to run this again).
+* **npm run dev** - This ups the frontend and backend server.
 * **npm run cypress** - this opens up the cypress application. Click on error_spec.js to run the associated test.
 
 ## Contributing

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+dist/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "cypress": "cypress open"
+    "cypress": "cypress open",
+    "bootstrap": "npm i; cd client; npm i; cd ../server; npm i;",
+    "dev": "concurrently --kill-others \"cd server; npm run local\" \" cd client; npm run start:dev\""
   },
   "repository": {
     "type": "git",
@@ -18,6 +20,7 @@
   },
   "homepage": "https://github.com/tminussi/hacktoberfest-2018-checker#readme",
   "devDependencies": {
+    "concurrently": "^4.0.1",
     "cypress": "^3.1.0"
   }
 }


### PR DESCRIPTION
This commit adds two commands for:
* **npm run bootstrap** - For app bootstrap/initialization: installation of node_modules in the root, client and server directory.
* **npm run dev** - For starting both the backend(serverless) and frontend(webpack-dev-server) - so that you can readily access the project at localhost:8080 with a single command.

How this will help?

This reduces the burden of 
* Installing node_modules in each of the root, client and server directory by going into each of these directories and firing the **npm i**. This one command does it all - **npm run bootstrap**
* Opening multiple terminals for running services in the client, server and root directory for frontend, backend or tests development. This one command does it all - **npm run dev**